### PR TITLE
Landing page transition added in Opne&close sidemenu

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "react-scripts": "^3.4.4",
     "react-spring": "^8.0.27",
     "react-toastify": "^6.0.9",
+    "react-transition-group": "^4.4.1",
     "styled-components": "^4.4.1"
   },
   "devDependencies": {

--- a/src/pages/LandingPage/LandingPage.js
+++ b/src/pages/LandingPage/LandingPage.js
@@ -68,41 +68,43 @@ const LandingPage = () => {
 
   return (
     <main data-testid="homepage" className="main-wrapper">
-      <SearchBox />
+      <div className="LandingMenuWrapper">
+        <SearchBox />
+        
       
-      {
-        state.isSearchToggled ?
-          <SearchPanel
-            data={state}
-            handleChange={handleChange}
-            handleSubmit={handleSubmit}
-            setState={setState} />
-          :
-          <div
-            data-testid="search-icon"
-            onClick={() => setState({
-              ...state,
-              isSearchToggled: !state.isSearchToggled
-            })}
-            className="search-icon">
-            <img src={menuIcon} />
-          </div>
-      }
+        <SearchPanel
+          data={state}
+          handleChange={handleChange}
+          handleSubmit={handleSubmit}
+          setState={setState}
+        />
+            
+        <SideMenu data={{...state}} setState={setState} /> 
+      </div>
+      <div
+        data-testid="search-icon"
+        onClick={() => setState({
+          ...state,
+          isSearchToggled: !state.isSearchToggled
+        })}
+        className="search-icon">
+        <img  src={menuIcon} />
+      </div>
+      
 
-      {
-        state.isNavToggled ?
-          <SideMenu data={{...state}} setState={setState} />
-          :
-          <div
-            data-testid="menu-icon"
-            onClick={() => setState({
-              ...state,
-              isNavToggled: !state.isNavToggled
-            })}
-            className="menu-icon">
-            <img src={menuIcon} />
-          </div>
-      }
+      
+      
+        
+      <div
+        data-testid="menu-icon"
+        onClick={() => setState({
+          ...state,
+          isNavToggled: !state.isNavToggled
+        })}
+        className="menu-icon">
+        <img src={menuIcon} />
+      </div>
+    
       <div id="bus-map">
         { 
           state.isSubmitted ?

--- a/src/pages/LandingPage/SearchPanel.js
+++ b/src/pages/LandingPage/SearchPanel.js
@@ -23,6 +23,7 @@ const SearchPanel = (props) => {
     props.setState({
       ...props.data,
       isSearchToggled: !props.data.isSearchToggled,
+      
     });
   };
 
@@ -84,7 +85,7 @@ const SearchPanel = (props) => {
   }, []);
 
   return (
-    <div className="sidebar">
+    <div className={`sidebar ${props.data.isSearchToggled ? "" : "sidebarHide"}`}>
       <div className="search-box">
         <div className="sidebar-top">
           {props.data.isSearchToggled ? (
@@ -102,8 +103,8 @@ const SearchPanel = (props) => {
         </div>
 
         <div className="sidebar-bottom">
-          <div>Location</div>
-          <div>Destination</div>
+          <p>Location</p>
+          <p>Destination</p>
           <HideOnMobile>Bus&nbsp;Location</HideOnMobile>
         </div>
 

--- a/src/pages/LandingPage/SideMenu.js
+++ b/src/pages/LandingPage/SideMenu.js
@@ -1,82 +1,40 @@
-import React from "react";
-import { Link as NavLink } from "react-router-dom";
-import backButton from "App/assets/images/back-button-navbar.svg";
-import facebook from "App/assets/images/facebook.svg";
-import instagram from "App/assets/images/instagram.svg";
-import twitter from "App/assets/images/twitter.svg";
-import closeIcon from "App/assets/images/close-icon.svg";
-import PropTypes from "prop-types";
-import { MobileFooter, FooterIcons } from "shared/styles/homepageStyles";
+import React, { useContext } from 'react';
+import { Link as NavLink } from 'react-router-dom';
+import backButton from 'App/assets/images/back-button-navbar.svg';
+import { AppContext } from 'context/AppProvider';
 
-const SideMenu = (props) => {
+const SideMenu = () => {
+  const { state, setState } = useContext(AppContext);
+
   const toggle = () => {
-    props.setState({
-      ...props.data,
-      isNavToggled: !props.data.isNavToggled,
+    setState({
+      ...state,
+      isNavToggled: !state.isNavToggled,
     });
-  };
+  }
 
   return (
-    <div>
-      <ul
-        data-testid="navbar"
-        style={{ display: props.data.isNavToggled ? "flex" : "none" }}
-        className="navbar"
-      >
-        {props.data.isNavToggled ? (
-          <img
-            onClick={toggle}
-            data-testid="navbar-hide-icon"
-            className="back-btn"
-            src={backButton}
-          />
-        ) : null}
-
-        <img src={closeIcon} className="close-btn" onClick={toggle} />
-
+    <div  className={`navbarLanding ${state.isNavToggled ? "" : "navbarLandingShow"}`}>
+      {/*Display a navigation bar*/}
+      <ul data-testid="navbar"  className="navbar">
+        <img onClick={toggle} className="back-btn" src={backButton} />
         <div>
           <li>
-            <NavLink className="text-center text-light" to="/">
-              Home
-            </NavLink>
+            <NavLink className="text-center text-light" to='/'>Home</NavLink>
           </li>
           <li>
-            <NavLink className="text-center text-light" to="/contact">
-              Contact Us
-            </NavLink>
+            <NavLink className="text-center text-light" to="/contact">Contact Us</NavLink>
           </li>
           <li>
-            <NavLink className="text-center text-light" to="/about">
-              About Us
-            </NavLink>
+            <NavLink className="text-center text-light" to="/about">About Us</NavLink>
           </li>
           <li>
-            <NavLink className="text-center text-light" to="/faqs">
-              FAQs
-            </NavLink>
+            <NavLink className="text-center text-light" to="/faqs">FAQs</NavLink>
           </li>
-          <li>
-            <NavLink className="text-center text-light" to="/AdminLogin">
-              Admin Login
-            </NavLink>
-          </li>
-          <MobileFooter>
-            <FooterIcons>
-              <img src={facebook} />
-              <img src={instagram} />
-              <img src={twitter} />
-            </FooterIcons>
-            <div>&copy; Orcas-Phantom 2020</div>
-          </MobileFooter>
         </div>
       </ul>
+
     </div>
   );
-};
-
-SideMenu.propTypes = {
-  data: PropTypes.object,
-  setState: PropTypes.func,
-};
-
+}
 export default SideMenu;

--- a/src/pages/LandingPage/css/style.css
+++ b/src/pages/LandingPage/css/style.css
@@ -1,3 +1,6 @@
+body{
+  overflow-x: hidden;
+}
 .main-wrapper {
   height: 100vh;
   max-height: 100vh;
@@ -9,29 +12,42 @@
   right: 0px;
   top: 0px;
 }
-
-.navbar {
-  position: relative;
+.navbarLanding{
+  box-shadow: -1px -1px 5px 0 rgba(32, 33, 36, 0.28);
+  height: 100%;
+  position: absolute;
+  right: 0px;
+  top: 0;
+  background: white;
+  color: black;
+  z-index: 99990;
+  width: 17%;
+  transition: 400ms ease;
+}
+.navbarLandingShow{
+  width: 0%;
+  transition: 400ms ease;
+}
+.LandingMenuWrapper{
   display: flex;
+  width: 100vw;
+  overflow-x: none;
+}
+.navbarLandingShow > .navbar{
+ display: none;
+}
+.navbar {
   flex-direction: column;
   align-items: center;
   justify-content: space-between;
   margin: 0;
   list-style: none;
-  box-shadow: -1px -1px 5px 0 rgba(32, 33, 36, 0.28);
-  padding: 1em;
+  padding: 1px 3rem;
   height: 100%;
-  width: 20%;
-  position: absolute;
-  right: 0px;
-  top: 0px;
-  background: white;
-  color: black;
-  z-index: 99990;
 }
 
 .navbar > div {
-  height: 100%;
+  height: 70%;
   width: 100%;
   display: flex;
   flex-direction: column;
@@ -48,6 +64,10 @@
 
 .navbar li a:hover {
   color: #386be4;
+}
+.landing-sidemenu{
+  width: 20%;
+  background: #fff;
 }
 
 .back-btn {
@@ -73,6 +93,42 @@
 .sidebar {
   z-index: 99990;
   box-shadow: 1px 1px 5px 0 rgba(32, 33, 36, 0.28);
+  width: 20%;
+  transition: 400ms ease;
+}
+.sidebarHide{
+  z-index: 99990;
+  margin-left: -20%;
+  transition: 400ms ease;
+}
+
+
+@media (max-width: 1080px){
+  .sidebar{
+    width: 30%;
+    transition: 400ms ease;
+  }
+  .sidebar-bottom{
+    font-size: 10px;
+  }
+  .sidebarHide{
+    z-index: 99990;
+    margin-left: -31%;
+    transition: 400ms ease;
+  }
+  .navbarLanding{
+    
+    width: 27%;
+    transition: 400ms ease;
+  }
+  .navbarLandingShow{
+    width: 0%;
+    transition: 400ms ease;
+  }
+  .navbarLandingShow > .navbar{
+   display: none;
+  }
+  
 }
 
 .sidebar > * {
@@ -127,7 +183,7 @@
 }
 
 .menu-icon {
-  z-index: 999999;
+  z-index: 9999;
   position: absolute;
   right: 1em;
   top: 1em;
@@ -142,7 +198,7 @@
 }
 
 .search-icon {
-  z-index: 999999;
+  z-index: 99980;
   position: absolute;
   cursor: pointer;
   top: 1em;
@@ -256,7 +312,6 @@
     list-style: none;
     box-shadow: 1px 1px 5px 0 rgba(32, 33, 36, 0.28);
     height: 100vh;
-    width: 20%;
     position: relative;
     left: 0px;
     top: 0px;
@@ -307,6 +362,7 @@
   .main-wrapper {
     width: 100vw;
     display: block;
+    overflow-x: hidden;
   }
 
   .search-box {

--- a/src/shared/styles/homepageStyles.js
+++ b/src/shared/styles/homepageStyles.js
@@ -121,7 +121,7 @@ export const SeparatorLine = Styled.hr`
   }
 `;
 
-export const HideOnMobile = Styled.div`
+export const HideOnMobile = Styled.p`
   @media (max-width: 768px) {
     display: none;
   }
@@ -201,6 +201,12 @@ export const SearchWrapper = Styled.div`
     * {
       font-size: small
     };
+  }
+  @media (max-width: 1080px) {
+    left: 28%;
+    
+    top: 2em;
+    
   }
 `;
 


### PR DESCRIPTION
### What this PR does

- Create transition while opening or clossing landing page side menus

### Task to be completed

> - Add transition in open and closing of landing page side menu

### Manual testing

- Clone the github repository

- run npm install

- run npm run dev to start the dev server

### Background context
N/A

### Relevant pivotal tracker stories
https://trello.com/c/Xqzn9Uxz/60-add-css-transition-effects-the-two-side-menu-on-the-home-page
### Screenshots
N/A