### PR TITLE
added dark and light tilelayers on the leaflet map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18698,6 +18698,14 @@
         "prop-types": "^15.5.8"
       }
     },
+    "react-switch": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-switch/-/react-switch-5.0.1.tgz",
+      "integrity": "sha512-Pa5kvqRfX85QUCK1Jv0rxyeElbC3aNpCP5hV0LoJpU/Y6kydf0t4kRriQ6ZYA4kxWwAYk/cH51T4/sPzV9mCgQ==",
+      "requires": {
+        "prop-types": "^15.6.2"
+      }
+    },
     "react-test-renderer": {
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.14.0.tgz",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "^3.4.4",
     "react-spring": "^8.0.27",
+    "react-switch": "^5.0.1",
     "react-toastify": "^6.0.9",
     "styled-components": "^4.4.1"
   },

--- a/src/__test__/homepage.test.js
+++ b/src/__test__/homepage.test.js
@@ -6,6 +6,7 @@ import App from "../App";
 import MapComponent from "../pages/LandingPage/MapComponent";
 import BusInfo from "pages/LandingPage/BusInfo";
 import { act } from "react-dom/test-utils";
+import ContextWrapper from "../context/AppProvider";
 
 afterEach(cleanup);
 
@@ -27,7 +28,10 @@ describe("Tests if all components are being rendered and work as expected", () =
 
   it(">>>> Map renders correctly", () => {
     const { getByTestId } = render(
-      <MapComponent lat={-1.9470658} lng={30.0915372}></MapComponent>
+      <ContextWrapper>
+        <MapComponent lat={-1.9470658} lng={30.0915372}></MapComponent>
+      </ContextWrapper>
+      
     );
     expect(getByTestId("map-component")).toBeValid();
   });
@@ -61,7 +65,18 @@ describe("Tests if all components are being rendered and work as expected", () =
     fireEvent.click(getByTestId("menu-icon"));
 
     fireEvent.click(getByTestId("navbar-hide-icon"));
+
   });
+
+  it(">>>> Dark and light map tilelayer should be toggled", () => {
+    const { getByTestId } = render(<App />);
+
+    fireEvent.click(getByTestId("switch-btn"));
+    expect(getByTestId("switch-btn")).toBeValid();
+    
+  });
+
+
 
   it(">>>> Search Panel can be toggled", () => {
     const { getByTestId } = render(<App />);
@@ -69,6 +84,7 @@ describe("Tests if all components are being rendered and work as expected", () =
     fireEvent.click(getByTestId("back-btn-search"));
 
     fireEvent.click(getByTestId("search-icon"));
+
   });
 
   it(">>>> Bus info toast is rendered correctly", () => {

--- a/src/pages/LandingPage/LandingPage.js
+++ b/src/pages/LandingPage/LandingPage.js
@@ -33,8 +33,10 @@ const LandingPage = () => {
       });
     }
   }
-
+  
+  
   useEffect(() => {
+    
     if (state.origin && state.destination) {
       let validInputs = false;
 
@@ -57,12 +59,19 @@ const LandingPage = () => {
         isSubmitted: false
       });
     }
+    handleSwitch();
   }, [state.origin, state.destination]);
 
   const handleSubmit = () => {
     setState({
       ...state,
       isSubmitted: true
+    });
+  }
+  const handleSwitch = () => {
+    setState({
+      ...state,
+      isSwitched: false
     });
   }
 
@@ -73,9 +82,10 @@ const LandingPage = () => {
       
       
         <SearchPanel
-          data={state}
+          data={{...state}}
           handleChange={handleChange}
           handleSubmit={handleSubmit}
+          handleSwitch={handleSwitch}
           setState={setState} />
         <SideMenu data={{...state}} setState={setState} />
       </div>
@@ -103,9 +113,16 @@ const LandingPage = () => {
       <div id="bus-map">
         { 
           state.isSubmitted ?
-            <MapComponent origin={state.coords.origin} destination={state.coords.destination} />
+            <MapComponent 
+              origin={state.coords.origin} 
+              destination={state.coords.destination} 
+              data={state}
+              setState={setState}
+            />
             :
-            <MapComponent />
+            <MapComponent 
+              data={state} 
+              setState={setState} />
         }
       </div>
 

--- a/src/pages/LandingPage/MapComponent.js
+++ b/src/pages/LandingPage/MapComponent.js
@@ -1,7 +1,8 @@
-import React, { useEffect, useState } from "react";
-import { MapContainer, TileLayer } from "react-leaflet";
+import React, { useEffect, useState,useContext } from "react";
+import { MapContainer, TileLayer,LayersControl } from "react-leaflet";
 import L, { Icon } from "leaflet";
 import PropTypes from "prop-types";
+import { AppContext } from 'context/AppProvider';
 
 import busStopsData from "./busStopData.json";
 import busStopIcon from "../../App/assets/images/bus-stop6.svg";
@@ -18,10 +19,13 @@ const stopIcon = new Icon({
 });
 
 const MapComponent = () => {
+  const { state } = useContext(AppContext);
   const onEachFeature=(feature, layer) =>{
     layer.setIcon(stopIcon);
     layer.bindPopup(`<p>Name: ${feature.properties.name}</p>`);
   }
+  const {BaseLayer}=LayersControl;
+
 
   const [map, setMap] = useState();
 
@@ -51,11 +55,25 @@ const MapComponent = () => {
         center={[-1.9440138579421542, 30.061919689178463]}
         zoom={12}
         whenCreated={setMap}
+        
       >
-        <TileLayer
-          attribution='&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
-          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-        />
+        <LayersControl >
+          <BaseLayer  name="dark" checked={typeof(state.isSwitched)=='undefined'? false : (state.isSwitched?true:false)} >
+            <TileLayer
+              attribution='&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+              url="https://api.mapbox.com/styles/v1/johnsonwambere/cki47ba4y7ct319qrb5fu8e0z/tiles/256/{z}/{x}/{y}@2x?access_token=pk.eyJ1Ijoiam9obnNvbndhbWJlcmUiLCJhIjoiY2tpM293dHVqMWM0czJ4bXNicnR1NGpodSJ9.dMW6nSid_3t3l6sUjB6XyQ"
+            />
+          </BaseLayer> 
+        </LayersControl>
+          
+        <LayersControl >
+          <BaseLayer   name="light"  checked={typeof(state.isSwitched)=='undefined'? true : (state.isSwitched?false:true)}>
+            <TileLayer
+              attribution='&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+              url="https://api.mapbox.com/styles/v1/johnsonwambere/cki4c7pl47hzk19oysw68nwmg/tiles/256/{z}/{x}/{y}@2x?access_token=pk.eyJ1Ijoiam9obnNvbndhbWJlcmUiLCJhIjoiY2tpM293dHVqMWM0czJ4bXNicnR1NGpodSJ9.dMW6nSid_3t3l6sUjB6XyQ"
+            />
+          </BaseLayer>
+        </LayersControl>
       </MapContainer>
     </div>
   );
@@ -65,6 +83,11 @@ const MapComponent = () => {
 MapComponent.propTypes = {
   origin: PropTypes.object,
   destination: PropTypes.object,
+  data: PropTypes.object,
+  setState: PropTypes.func,
+  handleSwitch:PropTypes.func,
+
 };
 
 export default MapComponent;
+

--- a/src/pages/LandingPage/SearchPanel.js
+++ b/src/pages/LandingPage/SearchPanel.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect,useContext } from "react";
 import directionIcon from "App/assets/images/direction-icon.svg";
 import backButton from "App/assets/images/back-button-homepage.svg";
 import PropTypes from "prop-types";
@@ -17,13 +17,23 @@ import {
   RouteWrapper,
   BusDetails,
 } from "shared/styles/homepageStyles";
+import Switch from "react-switch";
+import { AppContext } from 'context/AppProvider';
 
 const SearchPanel = (props) => {
+  const { state } = useContext(AppContext);
   const toggle = () => {
     props.setState({
       ...props.data,
       isSearchToggled: !props.data.isSearchToggled,
     });
+  };
+  const handleSwitch=()=> {
+    props.setState({
+      ...props.data,
+      isSwitched: !props.data.isSwitched,
+    });
+    
   };
 
   const [orig, setOrig] = useState("");
@@ -72,7 +82,7 @@ const SearchPanel = (props) => {
       props.handleChange(eventObj);
     }
   };
-
+  
   const getWidth = () => window.innerWidth;
 
   const [width, setWidth] = useState(getWidth());
@@ -82,6 +92,8 @@ const SearchPanel = (props) => {
   useEffect(() => {
     window.addEventListener("resize", handleResize);
   }, []);
+
+  
 
   return (
     <div className={`sidebar ${props.data.isSearchToggled ? "" : "sidebarHide"}`}>
@@ -234,6 +246,27 @@ const SearchPanel = (props) => {
             </div>
           ) : null}
         </BusDetails>
+
+
+        <label className="tileLayerSwitcher">
+          <Switch 
+            data-testid="switch-btn"
+            onChange={handleSwitch} 
+            checked={typeof(state.isSwitched)=='undefined'?false :state.isSwitched}
+            onColor="#d9e3e5"
+            offColor="#171717"
+            onHandleColor="#2693e6"
+            handleDiameter={24}
+            uncheckedIcon={false}
+            checkedIcon={false}
+            boxShadow="0px 1px 5px rgba(0, 0, 0, 0.6)"
+            height={20}
+            width={48}
+            className="react-switch"
+            id="icon-switch"
+          
+          />
+        </label>
       </div>
     </div>
   );
@@ -246,6 +279,7 @@ SearchPanel.propTypes = {
   onSelect: PropTypes.func,
   onSearch: PropTypes.func,
   setState: PropTypes.func,
+  handleSwitch:PropTypes.func,
 };
 
 export default SearchPanel;

--- a/src/pages/LandingPage/css/style.css
+++ b/src/pages/LandingPage/css/style.css
@@ -481,3 +481,9 @@ body{
       width: 100%;
     }
   }
+
+  /* tilelayer css */
+  .tileLayerSwitcher{
+    margin-right:auto;
+    margin-bottom: 5%;
+  }


### PR DESCRIPTION
#### What does this PR do?

- Add dark mode and light mode on leaflet map

#### Description of Task to be completed?

-Create a toggle on the side menu to switch the Tile layer style of the map


#### How should this be manually tested?

- Clone the branch, 
- Do `npm install` 
- Do `npm run dev`
- Then in click the toggle button at the bottom of the left-side menu

#### Any background context you want to provide?

- It should switch between the dark and light version of the same map as you click the switch button
#### What are the relevant Trello boards stories?

- https://trello.com/c/LjNZUR8z/59-create-a-toggle-on-the-side-menu-to-switch-the-tilelayer-style-of-the-maplight-dark

#### Screenshots (if appropriate)




![Screenshot from 2020-12-03 08-22-25](https://user-images.githubusercontent.com/59834399/100972104-df920580-3540-11eb-8e7c-44803e44c044.png)
![Screenshot from 2020-12-03 08-22-44](https://user-images.githubusercontent.com/59834399/100972118-e456b980-3540-11eb-97f5-23db1f5d47a2.png)


#### Questions:

- N/Q